### PR TITLE
Remove CI from PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,6 @@ name: CI
 
 on:
   push:
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Do not run "manual" CI on pull requests as it is being handled by pre-commit.ci now.
Note that pre-commit.ci runs on the commits in PR but "manual" checks just run on the whole repo so they can technically catch something else but it will be outside of PR scope. Doesn't matter much because all checks will run on the push anyway.

Right now on PRs:

![image](https://user-images.githubusercontent.com/12860284/123559152-ed3ffe80-d7a2-11eb-9715-27ba60b22146.png)

After the change, it will be only the last check (that basically runs all of the above). Unfortunately, it can't be split into separate checks.