### PR TITLE
Use OOIPy

### DIFF
--- a/.github/workflows/ooi_processing.yml
+++ b/.github/workflows/ooi_processing.yml
@@ -22,7 +22,7 @@ jobs:
       run: |
         python -m pip install -U pip
         python -m pip install -U setuptools wheel
-        python -m pip install obspy
+        python -m pip install ooipy
 
     - name: Execute Python script
       run: |

--- a/create_spectrogram.py
+++ b/create_spectrogram.py
@@ -15,7 +15,7 @@ def plot_psd(data, samplerate, NFFT=256, noverlap=128):
         `noverlap`: The number of points of overlap between blocks.
     """
     plt.specgram(data, Fs=samplerate, NFFT=NFFT, noverlap=noverlap)
-    plt.ylabel("Frequency")
+    plt.ylabel("Frequency [Hz]")
     cbar = plt.colorbar()
     cbar.set_label("DB")
 
@@ -33,15 +33,20 @@ def save_spectrogram(input_wav, plot_path=None, NFFT=256):
     samplerate, data = wavfile.read(input_wav)
     noverlap = NFFT // 2 if NFFT <= 128 else 128
 
+    title = input_wav.removesuffix(".wav")
+    plt.title(title)
     if len(data.shape) == 1:
         plot_psd(data, samplerate, NFFT, noverlap)
     else:
         plt.subplot(211)
-        plt.title("Channel 0 above, Channel 1 below")
         plot_psd(data[:, 0], samplerate, NFFT, noverlap)
+        title = f"{title}\nChannel 0 above, Channel 1 below"
+        plt.title(title)
 
         plt.subplot(212)
         plot_psd(data[:, 1], samplerate, NFFT, noverlap)
+
+    plt.xlabel("Time [s]")
 
     if plot_path is None:
         plot_path = input_wav.replace(".wav", ".png")

--- a/create_spectrogram.py
+++ b/create_spectrogram.py
@@ -5,8 +5,23 @@ import matplotlib.pyplot as plt
 from scipy.io import wavfile
 
 
-def create_spectrogram(input_wav, plot_path=None, NFFT=256):
+def plot_psd(data, samplerate, NFFT=256, noverlap=128):
     """Plots power spectral density spectrogram.
+
+    Args:
+        `data`: Array or sequence containing the data.
+        `samplerate`: The sampling frequency (samples per time unit).
+        `NFFT`: The number of data points used in each block for the FFT. A power 2 is most efficient.
+        `noverlap`: The number of points of overlap between blocks.
+    """
+    plt.specgram(data, Fs=samplerate, NFFT=NFFT, noverlap=noverlap)
+    plt.ylabel("Frequency")
+    cbar = plt.colorbar()
+    cbar.set_label("DB")
+
+
+def save_spectrogram(input_wav, plot_path=None, NFFT=256):
+    """Saves power spectral density spectrogram to file.
 
     Args:
         `input_wav`: Path to the input .wav file.
@@ -18,19 +33,15 @@ def create_spectrogram(input_wav, plot_path=None, NFFT=256):
     samplerate, data = wavfile.read(input_wav)
     noverlap = NFFT // 2 if NFFT <= 128 else 128
 
-    plt.subplot(211)
-    plt.title("Channel 0 above, Channel 1 below")
-    plt.specgram(data[:, 0], Fs=samplerate, NFFT=NFFT, noverlap=noverlap)
-    plt.ylabel("Frequency")
-    cbar = plt.colorbar()
-    cbar.set_label("DB")
+    if len(data.shape) == 1:
+        plot_psd(data, samplerate, NFFT, noverlap)
+    else:
+        plt.subplot(211)
+        plt.title("Channel 0 above, Channel 1 below")
+        plot_psd(data[:, 0], samplerate, NFFT, noverlap)
 
-    plt.subplot(212)
-    plt.specgram(data[:, 1], Fs=samplerate, NFFT=NFFT, noverlap=noverlap)
-    plt.xlabel("Time")
-    plt.ylabel("Frequency")
-    cbar = plt.colorbar()
-    cbar.set_label("DB")
+        plt.subplot(212)
+        plot_psd(data[:, 1], samplerate, NFFT, noverlap)
 
     if plot_path is None:
         plot_path = input_wav.replace(".wav", ".png")
@@ -60,4 +71,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    create_spectrogram(args.input, args.output, args.nfft)
+    save_spectrogram(args.input, args.output, args.nfft)

--- a/ooi_processing.py
+++ b/ooi_processing.py
@@ -1,6 +1,6 @@
+import datetime
 import logging
 import sys
-from datetime import datetime
 
 from ooipy.request import hydrophone_request
 
@@ -10,7 +10,9 @@ logging.basicConfig(
     format="%(levelname)s:%(message)s", stream=sys.stdout, level=logging.INFO
 )
 
-end_time = datetime.combine(datetime.today(), datetime.min.time())
+end_time = datetime.datetime.combine(
+    datetime.datetime.today(), datetime.datetime.min.time()
+)
 start_time = end_time - datetime.timedelta(days=1)
 segment_length = datetime.timedelta(minutes=5)
 node = "PC01A"

--- a/ooi_processing.py
+++ b/ooi_processing.py
@@ -21,8 +21,11 @@ node = "PC01A"
 while start_time < end_time:
     segment_end = min(start_time + segment_length, end_time)
     hydrophone_data = hydrophone_request.get_acoustic_data(
-        start_time, segment_end, node
+        start_time, segment_end, node, verbose=True
     )
+    if hydrophone_data is None:
+        logging.info(f"Could not get data from {start_time} to {end_time}")
+        continue
     datestr = start_time.strftime("%Y-%m-%dT%H-%M-%S-%f")[:-3]
     wav_name = f"{datestr}.wav"
     hydrophone_data.wav_write(wav_name)

--- a/ooi_processing.py
+++ b/ooi_processing.py
@@ -1,50 +1,26 @@
 import datetime
 import logging
-import re
 import sys
-from html.parser import HTMLParser
 
-import matplotlib.pyplot as plt
-import obspy
-import requests
+from ooipy.request import hydrophone_request
+
+from create_spectrogram import save_spectrogram
 
 logging.basicConfig(
     format="%(levelname)s:%(message)s", stream=sys.stdout, level=logging.INFO
 )
 
-
-# extracting link for last file today
-class MyHTMLParser(HTMLParser):
-    def handle_data(self, data):
-        if "HYVM2" in data:
-            filelist.append(data)
-
-
-yesterday = datetime.datetime.today() - datetime.timedelta(days=1)
-datestr = yesterday.strftime("%Y/%m/%d")
+end_time = datetime.datetime.today()
+start_time = end_time - datetime.timedelta(days=1)
+segment_length = datetime.timedelta(minutes=5)
 node = "PC01A"
-url = f"https://rawdata.oceanobservatories.org/files/RS01SBPS/{node}/08-HYDBBA103/{datestr}"
 
-page = requests.get(url)
-if page.status_code == 404:
-    print("Following directory doesn't exist:\n" + url)
-
-filelist = []
-parser = MyHTMLParser()
-parser.feed(str(page.content))
-
-for filename in filelist:
-    full_url = f"{url}/{filename}"
-    st = obspy.read(full_url)
-    st.filter("bandpass", freqmin=2000, freqmax=6000.0)
-    st.decimate(factor=10)
-    recording_time = re.search(r"OO-HYVM2--YDH-(.*?)\.mseed", filename).group(1)
-    # upload-artifact doesn't support ':' in filepaths!
-    recording_time = recording_time.replace(":", "-")
-    outfile = f"{recording_time}_spectrogram.png"
-    st.spectrogram(outfile=outfile, dbscale=True, wlen=0.1)
-    # Need to do some clearing, otherwise matplotlib hogs too much memory
-    # when saving plots to files
-    plt.cla()
-    plt.close("all")
-    logging.info("Finished " + filename)
+while start_time < end_time:
+    segment_end = min(start_time + segment_length, end_time)
+    hydrophone_data = hydrophone_request.get_acoustic_data(
+        start_time, segment_end, node
+    )
+    wav_name = f"{start_time}.wav"
+    hydrophone_data.wav_write(wav_name)
+    save_spectrogram(wav_name)
+    start_time = segment_end

--- a/ooi_processing.py
+++ b/ooi_processing.py
@@ -24,7 +24,8 @@ while start_time < end_time:
         start_time, segment_end, node, verbose=True
     )
     if hydrophone_data is None:
-        logging.info(f"Could not get data from {start_time} to {end_time}")
+        logging.info(f"Could not get data from {start_time} to {segment_end}")
+        start_time = segment_end
         continue
     datestr = start_time.strftime("%Y-%m-%dT%H-%M-%S-%f")[:-3]
     wav_name = f"{datestr}.wav"

--- a/ooi_processing.py
+++ b/ooi_processing.py
@@ -1,6 +1,6 @@
-import datetime
 import logging
 import sys
+from datetime import datetime
 
 from ooipy.request import hydrophone_request
 
@@ -10,7 +10,7 @@ logging.basicConfig(
     format="%(levelname)s:%(message)s", stream=sys.stdout, level=logging.INFO
 )
 
-end_time = datetime.datetime.today()
+end_time = datetime.combine(datetime.today(), datetime.time())
 start_time = end_time - datetime.timedelta(days=1)
 segment_length = datetime.timedelta(minutes=5)
 node = "PC01A"
@@ -20,7 +20,8 @@ while start_time < end_time:
     hydrophone_data = hydrophone_request.get_acoustic_data(
         start_time, segment_end, node
     )
-    wav_name = f"{start_time}.wav"
+    datestr = start_time.strftime("%Y-%m-%dT%H-%M-%S-%f")[:-3]
+    wav_name = f"{datestr}.wav"
     hydrophone_data.wav_write(wav_name)
     save_spectrogram(wav_name)
     start_time = segment_end

--- a/ooi_processing.py
+++ b/ooi_processing.py
@@ -10,7 +10,7 @@ logging.basicConfig(
     format="%(levelname)s:%(message)s", stream=sys.stdout, level=logging.INFO
 )
 
-end_time = datetime.combine(datetime.today(), datetime.time())
+end_time = datetime.combine(datetime.today(), datetime.min.time())
 start_time = end_time - datetime.timedelta(days=1)
 segment_length = datetime.timedelta(minutes=5)
 node = "PC01A"

--- a/ooi_processing.py
+++ b/ooi_processing.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import os
 import sys
 
 from ooipy.request import hydrophone_request
@@ -26,4 +27,5 @@ while start_time < end_time:
     wav_name = f"{datestr}.wav"
     hydrophone_data.wav_write(wav_name)
     save_spectrogram(wav_name)
+    os.remove(wav_name)
     start_time = segment_end

--- a/orcasound_processing.py
+++ b/orcasound_processing.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import ffmpeg
 import m3u8
 
-from create_spectrogram import create_spectrogram
+from create_spectrogram import save_spectrogram
 
 
 def convert_with_ffmpeg(input_file, output_file):
@@ -91,4 +91,4 @@ if __name__ == "__main__":
             Path(args.output).mkdir(parents=True, exist_ok=True)
             file_name = path.splitext(path.basename(input_wav))[0]
             output_fname = f"{path.normpath(args.output)}/{file_name}"
-        create_spectrogram(input_wav, output_fname, args.nfft)
+        save_spectrogram(input_wav, output_fname, args.nfft)


### PR DESCRIPTION
- I've reused spectrogram creation from Orcasound, had to modify it a bit to work for mono (OOI) and stereo (Orcasound) signals
- Resulting OOI processing script is really small and self-explanatory but a short overview is:
  For input start/end time, segment length and node:
  1. Get data from OOI using OOIPy (this will interpolate all gaps by default) for each segment
  2. Save it to .wav using
  3. Create a spectrogram
Start and end times are as before (previous and today's midnight) so we get data for yesterday.
I've set segment length as 5 minutes because it looks like it is the most common length in OOI data (they also have lots of short recordings).
Node is the same (`PC01A`).
As a result of this loop, we have exactly 288 files (24 hours * 60 minutes / 5 minutes) when previously we were processing each file individually. For example on July 4th there were 375 files total, some of them very short.
Another change: spectrograms. Previously we were applying bandpass filter to only look at the 2-6 kHz, now I just plot everything. Shouldn't matter because it was an example anyway. But we will probably add some parameters to spectrogram creation function to allow this (not in this PR?).

Before:

![image](https://user-images.githubusercontent.com/12860284/124597420-25fb6a00-de6c-11eb-84b1-58bca5312269.png)


After:

![image](https://user-images.githubusercontent.com/12860284/124597435-2bf14b00-de6c-11eb-89f7-d3d10b18dd87.png)

Actually looking at this I should add more info on our spectrograms (wave filename as a title (it will be start time), x axis title and y axis units).

Compare July 4th [old](https://github.com/orcasound/orca-action-workflow/actions/runs/1001108660) and [new](https://github.com/Molkree/orca-action-workflow/actions/runs/1002654455).