### PR TITLE
fix(ci): stay on Python 3.9 due to SciPy bug

### DIFF
--- a/.github/workflows/ooi_processing.yml
+++ b/.github/workflows/ooi_processing.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/orcasound_processing.yml
+++ b/.github/workflows/orcasound_processing.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.x'
+        python-version: '3.9'
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: '3.9'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
https://issueexplorer.com/issue/scipy/scipy/14738

Not adding anything to docs because it should be resolved as soon as SciPy releases a new version that installs on Python 3.10.