### PR TITLE
ci: run on latest Python

### DIFF
--- a/.github/workflows/ooi_processing.yml
+++ b/.github/workflows/ooi_processing.yml
@@ -33,10 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
+    - uses: actions/setup-python@v2
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/orcasound_processing.yml
+++ b/.github/workflows/orcasound_processing.yml
@@ -10,10 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
+    - uses: actions/setup-python@v2
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,6 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-python@v2
-        with:
-          python-version: '3.9'
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
SciPy installs fine on Python 3.10 now (https://github.com/scipy/scipy/releases/tag/v1.7.2) so we can revert #62.