### PR TITLE
ci: upper limit NumPy

### DIFF
--- a/.github/workflows/ooi_processing.yml
+++ b/.github/workflows/ooi_processing.yml
@@ -39,7 +39,7 @@ jobs:
       run: |
         python -m pip install -U pip
         python -m pip install -U setuptools wheel
-        python -m pip install ooipy
+        python -m pip install ooipy 'numpy<1.22'
 
     - name: Custom timeframe
       if: ${{ github.event.inputs.start_time }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools wheel
-          python -m pip install pytest ooipy
+          python -m pip install pytest ooipy 'numpy<1.22'
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This is simply to fix scheduled workflows, for more context and a better approach see #70.