### PR TITLE
Add rolling broadband ambient reference levels

### DIFF
--- a/.github/workflows/ambient_reference.yml
+++ b/.github/workflows/ambient_reference.yml
@@ -3,7 +3,7 @@ name: Rolling Broadband Reference
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '5 8 * * *'
 
 jobs:
   compute-reference:

--- a/.github/workflows/ambient_reference.yml
+++ b/.github/workflows/ambient_reference.yml
@@ -1,0 +1,31 @@
+name: Rolling Broadband Reference
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+jobs:
+  compute-reference:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip'
+        cache-dependency-path: requirements_reference.txt
+
+    - name: Install Python dependencies
+      run: pip install -r requirements_reference.txt
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v4
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: us-west-2
+
+    - name: Compute rolling reference levels
+      run: python ambient_reference.py

--- a/.github/workflows/ambient_reference.yml
+++ b/.github/workflows/ambient_reference.yml
@@ -3,7 +3,7 @@ name: Rolling Broadband Reference
 on:
   workflow_dispatch:
   schedule:
-    - cron: '5 8 * * *'
+    - cron: '0 6 * * *'
 
 jobs:
   compute-reference:

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -6,10 +6,11 @@ for all Orcasound hydrophones and write results to S3.
 import datetime as dt
 import io
 import traceback
+from dataclasses import asdict, dataclass
+from zoneinfo import ZoneInfo
 
 import boto3
 import polars as pl
-import pytz
 
 from orcasound_noise.pipeline.partitioned_accessor import PartitionedAccessor
 from orcasound_noise.utils import Hydrophone
@@ -17,7 +18,25 @@ from orcasound_noise.utils import Hydrophone
 S3_BUCKET = "acoustic-sandbox"
 S3_PREFIX = "ambient-sound-analysis/data/rolling_reference"
 WINDOW_DAYS = 7
-TIMEZONE = pytz.timezone("US/Pacific")
+TIMEZONE = ZoneInfo("US/Pacific")
+
+
+@dataclass
+class ReferenceRow:
+    date: dt.date
+    hydrophone: str
+    rolling_reference_db: float
+    sample_count: int
+    window_start: dt.datetime
+    window_end: dt.datetime
+
+
+def date_range(start: dt.date, end: dt.date):
+    """Yield dates from start through end inclusive."""
+    current = start
+    while current <= end:
+        yield current
+        current += dt.timedelta(days=1)
 
 
 def s3_key(hydrophone_name: str) -> str:
@@ -33,7 +52,8 @@ def read_existing(s3_client, hydrophone_name: str) -> pl.DataFrame | None:
         return pl.read_parquet(io.BytesIO(data))
     except s3_client.exceptions.NoSuchKey:
         return None
-    except Exception:
+    except Exception as e:
+        print(f"  Warning: could not read existing data for {hydrophone_name}: {e}")
         return None
 
 
@@ -42,7 +62,6 @@ def write_to_s3(s3_client, hydrophone_name: str, df: pl.DataFrame) -> None:
     key = s3_key(hydrophone_name)
     buf = io.BytesIO()
     df.write_parquet(buf)
-    buf.seek(0)
     s3_client.put_object(Bucket=S3_BUCKET, Key=key, Body=buf.getvalue())
     print(f"  Wrote {len(df)} rows to s3://{S3_BUCKET}/{key}")
 
@@ -51,7 +70,6 @@ def find_earliest_data(hydrophone: Hydrophone, today: dt.date) -> dt.date | None
     """Find earliest date with available data by probing progressively older dates."""
     # Try going back up to 2 years in weekly steps, then narrow down
     earliest_found = None
-    probe_date = today
 
     # First: coarse scan backwards in 30-day steps up to 730 days
     for days_back in range(0, 731, 30):
@@ -64,8 +82,8 @@ def find_earliest_data(hydrophone: Hydrophone, today: dt.date) -> dt.date | None
             bb_df = bb_lazy.collect()
             if bb_df.height > 0:
                 earliest_found = candidate
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"  Probe {candidate}: {e}")
 
     if earliest_found is None:
         return None
@@ -84,7 +102,8 @@ def find_earliest_data(hydrophone: Hydrophone, today: dt.date) -> dt.date | None
             bb_df = bb_lazy.collect()
             if bb_df.height > 0:
                 return candidate
-        except Exception:
+        except Exception as e:
+            print(f"  Probe {candidate}: {e}")
             continue
 
     return earliest_found
@@ -92,7 +111,7 @@ def find_earliest_data(hydrophone: Hydrophone, today: dt.date) -> dt.date | None
 
 def compute_reference_for_day(
     hydrophone: Hydrophone, target_date: dt.date
-) -> dict | None:
+) -> ReferenceRow | None:
     """Compute 5th percentile broadband dB for 7-day window ending on target_date."""
     end_time = dt.datetime.combine(
         target_date + dt.timedelta(days=1), dt.time.min
@@ -107,16 +126,15 @@ def compute_reference_for_day(
         return None
 
     ref_db = bb_df.select(pl.col("0").quantile(0.05)).item()
-    sample_count = bb_df.height
 
-    return {
-        "date": target_date,
-        "hydrophone": hydrophone.name,
-        "rolling_reference_db": float(ref_db),
-        "sample_count": sample_count,
-        "window_start": start_time.replace(tzinfo=None),
-        "window_end": end_time.replace(tzinfo=None),
-    }
+    return ReferenceRow(
+        date=target_date,
+        hydrophone=hydrophone.name,
+        rolling_reference_db=float(ref_db),
+        sample_count=bb_df.height,
+        window_start=start_time.replace(tzinfo=None),
+        window_end=end_time.replace(tzinfo=None),
+    )
 
 
 def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int:
@@ -144,28 +162,26 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int
         print(f"  Earliest data: {earliest}, starting reference from {start_date}")
 
     if start_date > today:
-        print(f"  Already up to date.")
+        print("  Already up to date.")
         return 0
 
     new_rows = []
-    current = start_date
-    while current <= today:
+    for current in date_range(start_date, today):
         try:
             row = compute_reference_for_day(hydrophone, current)
             if row is not None:
                 new_rows.append(row)
-                print(f"  {current}: {row['rolling_reference_db']:.1f} dB ({row['sample_count']} samples)")
+                print(f"  {current}: {row.rolling_reference_db:.1f} dB ({row.sample_count} samples)")
             else:
                 print(f"  {current}: no data in window, skipping")
         except Exception as e:
             print(f"  {current}: error - {e}")
-        current += dt.timedelta(days=1)
 
     if not new_rows:
         print(f"  No new data computed for {name}.")
         return 0
 
-    new_df = pl.DataFrame(new_rows).with_columns(
+    new_df = pl.DataFrame([asdict(row) for row in new_rows]).with_columns(
         pl.col("date").cast(pl.Date),
         pl.col("sample_count").cast(pl.Int64),
         pl.col("window_start").cast(pl.Datetime),
@@ -198,15 +214,15 @@ def main():
         except Exception:
             print(f"\nERROR processing {hydrophone.name}:")
             traceback.print_exc()
-            summary[hydrophone.name] = "FAILED"
+            summary[hydrophone.name] = None
 
     print("\n" + "=" * 60)
     print("Summary:")
     for name, result in summary.items():
-        if isinstance(result, int):
-            print(f"  {name}: {result} new rows")
+        if result is None:
+            print(f"  {name}: FAILED")
         else:
-            print(f"  {name}: {result}")
+            print(f"  {name}: {result} new rows")
     print("=" * 60)
 
 

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -128,10 +128,11 @@ def compute_bootstrap_reference(
     try:
         bb_df = (
             pl.scan_parquet(paths, storage_options={"aws_region": "us-west-2"})
-            .filter(pl.col(TIMESTAMP_COL).is_between(start_time, end_time))
+            .filter(pl.col(TIMESTAMP_COL).is_between(start_time, end_time, closed="left"))
             .collect()
         )
-    except Exception:
+    except Exception as e:
+        print(f"  Warning: bootstrap computation failed: {e}")
         return None
 
     if bb_df.height == 0:
@@ -157,10 +158,11 @@ def compute_reference_for_day(
     try:
         bb_df = (
             pl.scan_parquet(paths, storage_options={"aws_region": "us-west-2"})
-            .filter(pl.col(TIMESTAMP_COL).is_between(start_time, end_time))
+            .filter(pl.col(TIMESTAMP_COL).is_between(start_time, end_time, closed="left"))
             .collect()
         )
-    except Exception:
+    except Exception as e:
+        print(f"  Warning: scan_parquet failed for {hydrophone.value.name} on {target_date}: {e}")
         return None
 
     if bb_df.height == 0:

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -24,11 +24,7 @@ TIMEZONE = ZoneInfo("US/Pacific")
 @dataclass
 class ReferenceRow:
     date: dt.date
-    hydrophone: str
     rolling_reference_db: float
-    sample_count: int
-    window_start: dt.datetime
-    window_end: dt.datetime
 
 
 def date_range(start: dt.date, end: dt.date):
@@ -87,11 +83,7 @@ def compute_reference_for_day(
 
     return ReferenceRow(
         date=target_date,
-        hydrophone=hydrophone.name,
         rolling_reference_db=float(ref_db),
-        sample_count=bb_df.height,
-        window_start=start_time.replace(tzinfo=None),
-        window_end=end_time.replace(tzinfo=None),
     )
 
 
@@ -123,7 +115,7 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int
             row = compute_reference_for_day(hydrophone, current)
             if row is not None:
                 new_rows.append(row)
-                print(f"  {current}: {row.rolling_reference_db:.1f} dB ({row.sample_count} samples)")
+                print(f"  {current}: {row.rolling_reference_db:.1f} dB")
             else:
                 print(f"  {current}: no data in window, skipping")
         except Exception as e:
@@ -135,9 +127,6 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int
 
     new_df = pl.DataFrame([asdict(row) for row in new_rows]).with_columns(
         pl.col("date").cast(pl.Date),
-        pl.col("sample_count").cast(pl.Int64),
-        pl.col("window_start").cast(pl.Datetime),
-        pl.col("window_end").cast(pl.Datetime),
     )
 
     if existing_df is not None:

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -12,7 +12,7 @@ from zoneinfo import ZoneInfo
 import boto3
 import polars as pl
 
-from orcasound_noise.pipeline.partitioned_accessor import PartitionedAccessor
+from orcasound_noise.analysis.partitioned_accessor import PartitionedAccessor
 from orcasound_noise.utils import Hydrophone
 
 S3_BUCKET = "acoustic-sandbox"

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -67,14 +67,11 @@ def compute_reference_for_day(
     hydrophone: Hydrophone, target_date: dt.date
 ) -> ReferenceRow | None:
     """Compute 5th percentile broadband dB for 7-day window ending on target_date."""
-    end_time = dt.datetime.combine(
-        target_date + dt.timedelta(days=1), dt.time.min
-    ).replace(tzinfo=TIMEZONE)
+    end_time = dt.datetime.combine(target_date + dt.timedelta(days=1), dt.time.min)
     start_time = end_time - dt.timedelta(days=WINDOW_DAYS)
 
     accessor = PartitionedAccessor(hydrophone, start_time, end_time)
-    _, bb_lazy = accessor.get_dataframes()
-    bb_df = bb_lazy.collect()
+    _, bb_df = accessor.get_dataframes()
 
     if bb_df.height == 0:
         return None

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -66,48 +66,6 @@ def write_to_s3(s3_client, hydrophone_name: str, df: pl.DataFrame) -> None:
     print(f"  Wrote {len(df)} rows to s3://{S3_BUCKET}/{key}")
 
 
-def find_earliest_data(hydrophone: Hydrophone, today: dt.date) -> dt.date | None:
-    """Find earliest date with available data by probing progressively older dates."""
-    # Try going back up to 2 years in weekly steps, then narrow down
-    earliest_found = None
-
-    # First: coarse scan backwards in 30-day steps up to 730 days
-    for days_back in range(0, 731, 30):
-        candidate = today - dt.timedelta(days=days_back)
-        start = dt.datetime.combine(candidate, dt.time.min).replace(tzinfo=TIMEZONE)
-        end = start + dt.timedelta(days=1)
-        try:
-            accessor = PartitionedAccessor(hydrophone, start, end)
-            _, bb_lazy = accessor.get_dataframes()
-            bb_df = bb_lazy.collect()
-            if bb_df.height > 0:
-                earliest_found = candidate
-        except Exception as e:
-            print(f"  Probe {candidate}: {e}")
-
-    if earliest_found is None:
-        return None
-
-    # Fine-tune: scan forward from (earliest_found - 30 days) in daily steps
-    search_start = earliest_found - dt.timedelta(days=30)
-    for day_offset in range(31):
-        candidate = search_start + dt.timedelta(days=day_offset)
-        if candidate > today:
-            break
-        start = dt.datetime.combine(candidate, dt.time.min).replace(tzinfo=TIMEZONE)
-        end = start + dt.timedelta(days=1)
-        try:
-            accessor = PartitionedAccessor(hydrophone, start, end)
-            _, bb_lazy = accessor.get_dataframes()
-            bb_df = bb_lazy.collect()
-            if bb_df.height > 0:
-                return candidate
-        except Exception as e:
-            print(f"  Probe {candidate}: {e}")
-            continue
-
-    return earliest_found
-
 
 def compute_reference_for_day(
     hydrophone: Hydrophone, target_date: dt.date
@@ -152,14 +110,8 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int
         print(f"  Found existing data through {last_date}, computing from {start_date}")
     else:
         existing_df = None
-        print("  No existing data found, searching for earliest available data...")
-        earliest = find_earliest_data(hydrophone, today)
-        if earliest is None:
-            print(f"  No data found for {name}, skipping.")
-            return 0
-        # Need at least WINDOW_DAYS of data for a meaningful reference
-        start_date = earliest + dt.timedelta(days=WINDOW_DAYS)
-        print(f"  Earliest data: {earliest}, starting reference from {start_date}")
+        start_date = today - dt.timedelta(days=WINDOW_DAYS)
+        print(f"  No existing data found, starting from {start_date}")
 
     if start_date > today:
         print("  Already up to date.")

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -19,6 +19,9 @@ S3_BUCKET = "acoustic-sandbox"
 S3_PREFIX = "ambient-sound-analysis/data/rolling_reference"
 WINDOW_DAYS = 7
 TIMEZONE = ZoneInfo("US/Pacific")
+BB_REF = 1e-6  # 1 μPa reference for dB conversion
+BB_FREQ_LOW = 20
+BB_FREQ_HIGH = 20000
 
 
 @dataclass
@@ -71,12 +74,14 @@ def compute_reference_for_day(
     start_time = end_time - dt.timedelta(days=WINDOW_DAYS)
 
     accessor = PartitionedAccessor(hydrophone, start_time, end_time)
-    _, bb_df = accessor.get_dataframes()
+    bb_df = accessor.get_broadband(
+        freq_low=BB_FREQ_LOW, freq_high=BB_FREQ_HIGH, ref=BB_REF
+    ).collect()
 
     if bb_df.height == 0:
         return None
 
-    ref_db = bb_df.select(pl.col("0").quantile(0.05)).item()
+    ref_db = bb_df.select(pl.col("calc_bb").quantile(0.05)).item()
 
     return ReferenceRow(
         date=target_date,

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -6,6 +6,7 @@ Produces per-hydrophone ref files matching the schema expected by
 the pipeline (PR #79): date, bb_ref, comm_bb_ref, ship_bb_ref.
 """
 
+import argparse
 import datetime as dt
 import io
 import traceback
@@ -15,10 +16,11 @@ from zoneinfo import ZoneInfo
 import boto3
 import polars as pl
 
-from orcasound_noise.analysis.partitioned_accessor import PartitionedAccessor
 from orcasound_noise.utils import Hydrophone
 
 S3_BUCKET = "acoustic-sandbox"
+S3_DATA_PREFIX = "ambient-sound-analysis/data_3.0"
+TEST_PREFIX = "test/ambient_reference"
 WINDOW_DAYS = 7
 TIMEZONE = ZoneInfo("US/Pacific")
 
@@ -26,6 +28,7 @@ TIMEZONE = ZoneInfo("US/Pacific")
 BB_COL = "bb_o"
 COMM_BB_COL = "comm_bb_o"
 SHIP_BB_COL = "ship_bb_o"
+TIMESTAMP_COL = "ind"
 
 
 @dataclass
@@ -44,16 +47,32 @@ def date_range(start: dt.date, end: dt.date):
         current += dt.timedelta(days=1)
 
 
-def s3_ref_key(hydrophone: Hydrophone) -> str:
+def s3_ref_key(hydrophone: Hydrophone, test_mode: bool = False) -> str:
     """S3 key matching the path the pipeline reads refs from."""
     name = hydrophone.value.name
-    folder = hydrophone.value.save_folder
-    return f"{folder}/ref/hydrophone={name}/{name}_refs.parquet"
+    key = f"{S3_DATA_PREFIX}/ref/hydrophone={name}/{name}_refs.parquet"
+    if test_mode:
+        key = f"{TEST_PREFIX}/{key}"
+    return key
 
 
-def read_existing(s3_client, hydrophone: Hydrophone) -> pl.DataFrame | None:
+def bb_paths_for_range(hydrophone: Hydrophone, start: dt.date, end: dt.date) -> list[str]:
+    """Build S3 glob paths for broadband parquets over a date range."""
+    name = hydrophone.value.name
+    paths = []
+    d = start
+    while d <= end:
+        paths.append(
+            f"s3://{S3_BUCKET}/{S3_DATA_PREFIX}/broadband/hydrophone={name}"
+            f"/year={d.year}/month={d.month:02d}/day={d.day:02d}/*.parquet"
+        )
+        d += dt.timedelta(days=1)
+    return paths
+
+
+def read_existing(s3_client, hydrophone: Hydrophone, test_mode: bool = False) -> pl.DataFrame | None:
     """Read existing reference parquet from S3, or return None."""
-    key = s3_ref_key(hydrophone)
+    key = s3_ref_key(hydrophone, test_mode)
     try:
         obj = s3_client.get_object(Bucket=S3_BUCKET, Key=key)
         data = obj["Body"].read()
@@ -65,9 +84,9 @@ def read_existing(s3_client, hydrophone: Hydrophone) -> pl.DataFrame | None:
         return None
 
 
-def write_to_s3(s3_client, hydrophone: Hydrophone, df: pl.DataFrame) -> None:
+def write_to_s3(s3_client, hydrophone: Hydrophone, df: pl.DataFrame, test_mode: bool = False) -> None:
     """Write reference parquet to S3."""
-    key = s3_ref_key(hydrophone)
+    key = s3_ref_key(hydrophone, test_mode)
     buf = io.BytesIO()
     df.write_parquet(buf)
     s3_client.put_object(Bucket=S3_BUCKET, Key=key, Body=buf.getvalue())
@@ -81,8 +100,15 @@ def compute_reference_for_day(
     end_time = dt.datetime.combine(target_date + dt.timedelta(days=1), dt.time.min)
     start_time = end_time - dt.timedelta(days=WINDOW_DAYS)
 
-    accessor = PartitionedAccessor(hydrophone, start_time, end_time)
-    _, bb_df = accessor.get_dataframes()
+    paths = bb_paths_for_range(hydrophone, start_time.date(), end_time.date())
+    try:
+        bb_df = (
+            pl.scan_parquet(paths, storage_options={"aws_region": "us-west-2"})
+            .filter(pl.col(TIMESTAMP_COL).is_between(start_time, end_time))
+            .collect()
+        )
+    except Exception:
+        return None
 
     if bb_df.height == 0:
         return None
@@ -101,12 +127,12 @@ def compute_reference_for_day(
     )
 
 
-def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int:
+def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date, test_mode: bool = False) -> int:
     """Process a single hydrophone. Returns number of new rows added."""
     name = hydrophone.name
     print(f"\nProcessing {name}...")
 
-    existing_df = read_existing(s3_client, hydrophone)
+    existing_df = read_existing(s3_client, hydrophone, test_mode)
 
     if existing_df is not None and len(existing_df) > 0:
         last_date = existing_df.select(pl.col("date").max()).item()
@@ -148,13 +174,20 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int
     else:
         combined = new_df
 
-    write_to_s3(s3_client, hydrophone, combined)
+    write_to_s3(s3_client, hydrophone, combined, test_mode)
     return len(new_rows)
 
 
 def main():
+    parser = argparse.ArgumentParser(description="Compute rolling broadband reference levels")
+    parser.add_argument("--test", action="store_true",
+                        help=f"Write to test prefix ({TEST_PREFIX}/) instead of production paths")
+    args = parser.parse_args()
+
     print("=" * 60)
     print("Rolling Broadband Reference Level Computation")
+    if args.test:
+        print(f"*** TEST MODE — writing to {TEST_PREFIX}/ ***")
     print("=" * 60)
 
     s3_client = boto3.client("s3")
@@ -163,8 +196,10 @@ def main():
 
     summary = {}
     for hydrophone in Hydrophone:
+        if hydrophone.name == "HPhoneTup":
+            continue
         try:
-            count = process_hydrophone(s3_client, hydrophone, today)
+            count = process_hydrophone(s3_client, hydrophone, today, args.test)
             summary[hydrophone.name] = count
         except Exception:
             print(f"\nERROR processing {hydrophone.name}:")

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -50,7 +50,7 @@ def date_range(start: dt.date, end: dt.date):
 def s3_ref_key(hydrophone: Hydrophone, test_mode: bool = False) -> str:
     """S3 key matching the path the pipeline reads refs from."""
     name = hydrophone.value.name
-    key = f"{S3_DATA_PREFIX}/ref/hydrophone={name}/{name}_refs.parquet"
+    key = f"{S3_DATA_PREFIX}/ref/hydrophone={name}/{name}_ref.parquet"
     if test_mode:
         key = f"{TEST_PREFIX}/{key}"
     return key
@@ -91,6 +91,59 @@ def write_to_s3(s3_client, hydrophone: Hydrophone, df: pl.DataFrame, test_mode: 
     df.write_parquet(buf)
     s3_client.put_object(Bucket=S3_BUCKET, Key=key, Body=buf.getvalue())
     print(f"  Wrote {len(df)} rows to s3://{S3_BUCKET}/{key}")
+
+
+def find_earliest_data_date(s3_client, hydrophone: Hydrophone) -> dt.date | None:
+    """Find the earliest date with broadband data via S3 listing."""
+    name = hydrophone.value.name
+    prefix = f"{S3_DATA_PREFIX}/broadband/hydrophone={name}/year="
+    resp = s3_client.list_objects_v2(Bucket=S3_BUCKET, Prefix=prefix, MaxKeys=1)
+    if resp.get("KeyCount", 0) == 0:
+        return None
+    # First key is the earliest (S3 lists lexicographically)
+    # e.g. .../year=2026/month=03/day=01/file.parquet
+    key = resp["Contents"][0]["Key"]
+    parts = key.split("/")
+    year = month = day = None
+    for part in parts:
+        if part.startswith("year="):
+            year = int(part.split("=")[1])
+        elif part.startswith("month="):
+            month = int(part.split("=")[1])
+        elif part.startswith("day="):
+            day = int(part.split("=")[1])
+    if year and month and day:
+        return dt.date(year, month, day)
+    return None
+
+
+def compute_bootstrap_reference(
+    hydrophone: Hydrophone, earliest_date: dt.date
+) -> tuple[float, float, float] | None:
+    """Compute 5th percentile over the first WINDOW_DAYS days of data."""
+    start_time = dt.datetime.combine(earliest_date, dt.time.min)
+    end_time = dt.datetime.combine(earliest_date + dt.timedelta(days=WINDOW_DAYS), dt.time.min)
+
+    paths = bb_paths_for_range(hydrophone, earliest_date, earliest_date + dt.timedelta(days=WINDOW_DAYS - 1))
+    try:
+        bb_df = (
+            pl.scan_parquet(paths, storage_options={"aws_region": "us-west-2"})
+            .filter(pl.col(TIMESTAMP_COL).is_between(start_time, end_time))
+            .collect()
+        )
+    except Exception:
+        return None
+
+    if bb_df.height == 0:
+        return None
+
+    quantiles = bb_df.select(
+        pl.col(BB_COL).quantile(0.05).alias("bb_ref"),
+        pl.col(COMM_BB_COL).quantile(0.05).alias("comm_bb_ref"),
+        pl.col(SHIP_BB_COL).quantile(0.05).alias("ship_bb_ref"),
+    ).row(0)
+
+    return (float(quantiles[0]), float(quantiles[1]), float(quantiles[2]))
 
 
 def compute_reference_for_day(
@@ -135,11 +188,18 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date, test_m
     existing_df = read_existing(s3_client, hydrophone, test_mode)
 
     if existing_df is not None and len(existing_df) > 0:
-        last_date = existing_df.select(pl.col("date").max()).item()
-        if isinstance(last_date, dt.datetime):
-            last_date = last_date.date()
-        start_date = last_date + dt.timedelta(days=1)
-        print(f"  Found existing data through {last_date}, computing from {start_date}")
+        # Keep only historical rows (before today); we'll recompute today and forward
+        existing_df = existing_df.filter(pl.col("date") < today)
+        if len(existing_df) > 0:
+            last_date = existing_df.select(pl.col("date").max()).item()
+            if isinstance(last_date, dt.datetime):
+                last_date = last_date.date()
+            start_date = last_date + dt.timedelta(days=1)
+            print(f"  Found existing data through {last_date}, computing from {start_date}")
+        else:
+            existing_df = None
+            start_date = today - dt.timedelta(days=WINDOW_DAYS)
+            print(f"  No historical data before today, starting from {start_date}")
     else:
         existing_df = None
         start_date = today - dt.timedelta(days=WINDOW_DAYS)
@@ -149,15 +209,37 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date, test_m
         print("  Already up to date.")
         return 0
 
+    # Find earliest data date and compute bootstrap reference for early days
+    earliest_date = find_earliest_data_date(s3_client, hydrophone)
+    bootstrap_ref = None
+    rolling_start_date = None
+    if earliest_date is not None:
+        rolling_start_date = earliest_date + dt.timedelta(days=WINDOW_DAYS)
+        if start_date < rolling_start_date:
+            bootstrap_ref = compute_bootstrap_reference(hydrophone, earliest_date)
+            if bootstrap_ref:
+                print(f"  Bootstrap ref (first {WINDOW_DAYS} days from {earliest_date}): "
+                      f"bb={bootstrap_ref[0]:.1f} comm={bootstrap_ref[1]:.1f} ship={bootstrap_ref[2]:.1f} dB")
+
     new_rows = []
     for current in date_range(start_date, today):
         try:
-            row = compute_reference_for_day(hydrophone, current)
-            if row is not None:
+            if rolling_start_date and current < rolling_start_date and bootstrap_ref:
+                row = ReferenceRow(
+                    date=current,
+                    bb_ref=bootstrap_ref[0],
+                    comm_bb_ref=bootstrap_ref[1],
+                    ship_bb_ref=bootstrap_ref[2],
+                )
                 new_rows.append(row)
-                print(f"  {current}: bb={row.bb_ref:.1f} comm={row.comm_bb_ref:.1f} ship={row.ship_bb_ref:.1f} dB")
+                print(f"  {current}: bb={row.bb_ref:.1f} comm={row.comm_bb_ref:.1f} ship={row.ship_bb_ref:.1f} dB (bootstrap)")
             else:
-                print(f"  {current}: no data in window, skipping")
+                row = compute_reference_for_day(hydrophone, current)
+                if row is not None:
+                    new_rows.append(row)
+                    print(f"  {current}: bb={row.bb_ref:.1f} comm={row.comm_bb_ref:.1f} ship={row.ship_bb_ref:.1f} dB")
+                else:
+                    print(f"  {current}: no data in window, skipping")
         except Exception as e:
             print(f"  {current}: error - {e}")
 

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -2,6 +2,11 @@
 Compute rolling 7-day broadband reference levels (5th percentile)
 for all Orcasound hydrophones and write results to S3.
 
+Uses the most recent 604,800 data points (7 days at 1-second resolution)
+ending at "now", looking back up to 14 calendar days to find enough data.
+Stores the result under tomorrow's date so the PSD pipeline always has a
+ref value available for any day it runs.
+
 Produces per-hydrophone ref files matching the schema expected by
 the pipeline (PR #79): date, bb_ref, comm_bb_ref, ship_bb_ref.
 """
@@ -22,6 +27,8 @@ S3_BUCKET = "acoustic-sandbox"
 S3_DATA_PREFIX = "ambient-sound-analysis/data_3.0"
 TEST_PREFIX = "test/ambient_reference"
 WINDOW_DAYS = 7
+TARGET_ROWS = WINDOW_DAYS * 24 * 60 * 60  # 604,800 seconds of data
+MAX_LOOKBACK_DAYS = 14
 TIMEZONE = ZoneInfo("US/Pacific")
 
 # data_3.0 broadband columns
@@ -38,13 +45,6 @@ class ReferenceRow:
     comm_bb_ref: float
     ship_bb_ref: float
 
-
-def date_range(start: dt.date, end: dt.date):
-    """Yield dates from start through end inclusive."""
-    current = start
-    while current <= end:
-        yield current
-        current += dt.timedelta(days=1)
 
 
 def s3_ref_key(hydrophone: Hydrophone, test_mode: bool = False) -> str:
@@ -147,26 +147,47 @@ def compute_bootstrap_reference(
     return (float(quantiles[0]), float(quantiles[1]), float(quantiles[2]))
 
 
-def compute_reference_for_day(
-    hydrophone: Hydrophone, target_date: dt.date
+def compute_reference(
+    hydrophone: Hydrophone, now: dt.datetime, ref_date: dt.date
 ) -> ReferenceRow | None:
-    """Compute 5th percentile for bb, comm, and ship bands over a 7-day window."""
-    end_time = dt.datetime.combine(target_date + dt.timedelta(days=1), dt.time.min)
-    start_time = end_time - dt.timedelta(days=WINDOW_DAYS)
+    """Compute 5th percentile over the most recent TARGET_ROWS data points.
 
-    paths = bb_paths_for_range(hydrophone, start_time.date(), end_time.date())
-    try:
-        bb_df = (
-            pl.scan_parquet(paths, storage_options={"aws_region": "us-west-2"})
-            .filter(pl.col(TIMESTAMP_COL).is_between(start_time, end_time, closed="left"))
-            .collect()
+    Loads data backward from `now`, expanding the calendar window day-by-day
+    up to MAX_LOOKBACK_DAYS. If not enough rows are found, logs a warning
+    and uses whatever data is available.
+    """
+    name = hydrophone.value.name
+
+    # Strip timezone for filtering — parquet ind column is naive datetime[ns]
+    now_naive = now.replace(tzinfo=None)
+
+    # Start with WINDOW_DAYS and expand if needed
+    for lookback in range(WINDOW_DAYS, MAX_LOOKBACK_DAYS + 1):
+        start_time = now_naive - dt.timedelta(days=lookback)
+        paths = bb_paths_for_range(hydrophone, start_time.date(), now_naive.date())
+        try:
+            bb_df = (
+                pl.scan_parquet(paths, storage_options={"aws_region": "us-west-2"})
+                .filter(pl.col(TIMESTAMP_COL).is_between(start_time, now_naive, closed="left"))
+                .sort(TIMESTAMP_COL, descending=True)
+                .head(TARGET_ROWS)
+                .collect()
+            )
+        except Exception as e:
+            print(f"  Warning: scan_parquet failed for {name} (lookback={lookback}d): {e}")
+            return None
+
+        if bb_df.height >= TARGET_ROWS:
+            print(f"  Collected {bb_df.height} rows ({lookback}d lookback)")
+            break
+    else:
+        # Exhausted MAX_LOOKBACK_DAYS
+        if bb_df.height == 0:
+            return None
+        print(
+            f"  WARNING: only {bb_df.height}/{TARGET_ROWS} rows found after "
+            f"{MAX_LOOKBACK_DAYS}d lookback for {name} — significant data gap likely"
         )
-    except Exception as e:
-        print(f"  Warning: scan_parquet failed for {hydrophone.value.name} on {target_date}: {e}")
-        return None
-
-    if bb_df.height == 0:
-        return None
 
     quantiles = bb_df.select(
         pl.col(BB_COL).quantile(0.05).alias("bb_ref"),
@@ -175,91 +196,70 @@ def compute_reference_for_day(
     ).row(0)
 
     return ReferenceRow(
-        date=target_date,
+        date=ref_date,
         bb_ref=float(quantiles[0]),
         comm_bb_ref=float(quantiles[1]),
         ship_bb_ref=float(quantiles[2]),
     )
 
 
-def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date, test_mode: bool = False) -> int:
-    """Process a single hydrophone. Returns number of new rows added."""
+def process_hydrophone(
+    s3_client, hydrophone: Hydrophone, now: dt.datetime, tomorrow: dt.date, test_mode: bool = False
+) -> int:
+    """Process a single hydrophone. Computes one ref row for tomorrow. Returns 1 on success, 0 otherwise."""
     name = hydrophone.name
     print(f"\nProcessing {name}...")
 
     existing_df = read_existing(s3_client, hydrophone, test_mode)
 
+    # Keep all rows except tomorrow (we'll recompute it)
     if existing_df is not None and len(existing_df) > 0:
-        # Keep only historical rows (before today); we'll recompute today and forward
-        existing_df = existing_df.filter(pl.col("date") < today)
-        if len(existing_df) > 0:
-            last_date = existing_df.select(pl.col("date").max()).item()
-            if isinstance(last_date, dt.datetime):
-                last_date = last_date.date()
-            start_date = last_date + dt.timedelta(days=1)
-            print(f"  Found existing data through {last_date}, computing from {start_date}")
-        else:
-            existing_df = None
-            start_date = today - dt.timedelta(days=WINDOW_DAYS)
-            print(f"  No historical data before today, starting from {start_date}")
+        existing_df = existing_df.filter(pl.col("date") != tomorrow)
+        print(f"  Existing ref has {len(existing_df)} rows (excluding tomorrow)")
     else:
         existing_df = None
-        start_date = today - dt.timedelta(days=WINDOW_DAYS)
-        print(f"  No existing data found, starting from {start_date}")
+        print("  No existing ref data found")
 
-    if start_date > today:
-        print("  Already up to date.")
-        return 0
-
-    # Find earliest data date and compute bootstrap reference for early days
+    # Check if we have enough data history for a rolling window
     earliest_date = find_earliest_data_date(s3_client, hydrophone)
-    bootstrap_ref = None
-    rolling_start_date = None
-    if earliest_date is not None:
-        rolling_start_date = earliest_date + dt.timedelta(days=WINDOW_DAYS)
-        if start_date < rolling_start_date:
-            bootstrap_ref = compute_bootstrap_reference(hydrophone, earliest_date)
-            if bootstrap_ref:
-                print(f"  Bootstrap ref (first {WINDOW_DAYS} days from {earliest_date}): "
-                      f"bb={bootstrap_ref[0]:.1f} comm={bootstrap_ref[1]:.1f} ship={bootstrap_ref[2]:.1f} dB")
-
-    new_rows = []
-    for current in date_range(start_date, today):
-        try:
-            if rolling_start_date and current < rolling_start_date and bootstrap_ref:
-                row = ReferenceRow(
-                    date=current,
-                    bb_ref=bootstrap_ref[0],
-                    comm_bb_ref=bootstrap_ref[1],
-                    ship_bb_ref=bootstrap_ref[2],
-                )
-                new_rows.append(row)
-                print(f"  {current}: bb={row.bb_ref:.1f} comm={row.comm_bb_ref:.1f} ship={row.ship_bb_ref:.1f} dB (bootstrap)")
-            else:
-                row = compute_reference_for_day(hydrophone, current)
-                if row is not None:
-                    new_rows.append(row)
-                    print(f"  {current}: bb={row.bb_ref:.1f} comm={row.comm_bb_ref:.1f} ship={row.ship_bb_ref:.1f} dB")
-                else:
-                    print(f"  {current}: no data in window, skipping")
-        except Exception as e:
-            print(f"  {current}: error - {e}")
-
-    if not new_rows:
-        print(f"  No new data computed for {name}.")
+    if earliest_date is None:
+        print(f"  No broadband data found for {name}, skipping")
         return 0
 
-    new_df = pl.DataFrame([asdict(row) for row in new_rows]).with_columns(
+    rolling_start_date = earliest_date + dt.timedelta(days=WINDOW_DAYS)
+    if now.date() < rolling_start_date:
+        # Not enough history — use bootstrap (5th percentile of all available data)
+        bootstrap_ref = compute_bootstrap_reference(hydrophone, earliest_date)
+        if bootstrap_ref is None:
+            print(f"  Bootstrap computation failed for {name}, skipping")
+            return 0
+        row = ReferenceRow(
+            date=tomorrow,
+            bb_ref=bootstrap_ref[0],
+            comm_bb_ref=bootstrap_ref[1],
+            ship_bb_ref=bootstrap_ref[2],
+        )
+        print(f"  {tomorrow}: bb={row.bb_ref:.1f} comm={row.comm_bb_ref:.1f} "
+              f"ship={row.ship_bb_ref:.1f} dB (bootstrap)")
+    else:
+        row = compute_reference(hydrophone, now, tomorrow)
+        if row is None:
+            print(f"  No data found for {name}, skipping")
+            return 0
+        print(f"  {tomorrow}: bb={row.bb_ref:.1f} comm={row.comm_bb_ref:.1f} "
+              f"ship={row.ship_bb_ref:.1f} dB")
+
+    new_df = pl.DataFrame([asdict(row)]).with_columns(
         pl.col("date").cast(pl.Date),
     )
 
-    if existing_df is not None:
+    if existing_df is not None and len(existing_df) > 0:
         combined = pl.concat([existing_df, new_df])
     else:
         combined = new_df
 
     write_to_s3(s3_client, hydrophone, combined, test_mode)
-    return len(new_rows)
+    return 1
 
 
 def main():
@@ -275,15 +275,17 @@ def main():
     print("=" * 60)
 
     s3_client = boto3.client("s3")
-    today = dt.datetime.now(TIMEZONE).date()
-    print(f"Today: {today}")
+    now = dt.datetime.now(TIMEZONE)
+    tomorrow = (now + dt.timedelta(days=1)).date()
+    print(f"Now: {now.strftime('%Y-%m-%d %H:%M:%S %Z')}")
+    print(f"Computing ref for: {tomorrow}")
 
     summary = {}
     for hydrophone in Hydrophone:
         if hydrophone.name == "HPhoneTup":
             continue
         try:
-            count = process_hydrophone(s3_client, hydrophone, today, args.test)
+            count = process_hydrophone(s3_client, hydrophone, now, tomorrow, args.test)
             summary[hydrophone.name] = count
         except Exception:
             print(f"\nERROR processing {hydrophone.name}:")

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -1,0 +1,214 @@
+"""
+Compute rolling 7-day broadband reference levels (5th percentile)
+for all Orcasound hydrophones and write results to S3.
+"""
+
+import datetime as dt
+import io
+import traceback
+
+import boto3
+import polars as pl
+import pytz
+
+from orcasound_noise.pipeline.partitioned_accessor import PartitionedAccessor
+from orcasound_noise.utils import Hydrophone
+
+S3_BUCKET = "acoustic-sandbox"
+S3_PREFIX = "ambient-sound-analysis/data/rolling_reference"
+WINDOW_DAYS = 7
+TIMEZONE = pytz.timezone("US/Pacific")
+
+
+def s3_key(hydrophone_name: str) -> str:
+    return f"{S3_PREFIX}/{hydrophone_name}_reference.parquet"
+
+
+def read_existing(s3_client, hydrophone_name: str) -> pl.DataFrame | None:
+    """Read existing reference parquet from S3, or return None."""
+    key = s3_key(hydrophone_name)
+    try:
+        obj = s3_client.get_object(Bucket=S3_BUCKET, Key=key)
+        data = obj["Body"].read()
+        return pl.read_parquet(io.BytesIO(data))
+    except s3_client.exceptions.NoSuchKey:
+        return None
+    except Exception:
+        return None
+
+
+def write_to_s3(s3_client, hydrophone_name: str, df: pl.DataFrame) -> None:
+    """Write reference parquet to S3."""
+    key = s3_key(hydrophone_name)
+    buf = io.BytesIO()
+    df.write_parquet(buf)
+    buf.seek(0)
+    s3_client.put_object(Bucket=S3_BUCKET, Key=key, Body=buf.getvalue())
+    print(f"  Wrote {len(df)} rows to s3://{S3_BUCKET}/{key}")
+
+
+def find_earliest_data(hydrophone: Hydrophone, today: dt.date) -> dt.date | None:
+    """Find earliest date with available data by probing progressively older dates."""
+    # Try going back up to 2 years in weekly steps, then narrow down
+    earliest_found = None
+    probe_date = today
+
+    # First: coarse scan backwards in 30-day steps up to 730 days
+    for days_back in range(0, 731, 30):
+        candidate = today - dt.timedelta(days=days_back)
+        start = dt.datetime.combine(candidate, dt.time.min).replace(tzinfo=TIMEZONE)
+        end = start + dt.timedelta(days=1)
+        try:
+            accessor = PartitionedAccessor(hydrophone, start, end)
+            _, bb_lazy = accessor.get_dataframes()
+            bb_df = bb_lazy.collect()
+            if bb_df.height > 0:
+                earliest_found = candidate
+        except Exception:
+            pass
+
+    if earliest_found is None:
+        return None
+
+    # Fine-tune: scan forward from (earliest_found - 30 days) in daily steps
+    search_start = earliest_found - dt.timedelta(days=30)
+    for day_offset in range(31):
+        candidate = search_start + dt.timedelta(days=day_offset)
+        if candidate > today:
+            break
+        start = dt.datetime.combine(candidate, dt.time.min).replace(tzinfo=TIMEZONE)
+        end = start + dt.timedelta(days=1)
+        try:
+            accessor = PartitionedAccessor(hydrophone, start, end)
+            _, bb_lazy = accessor.get_dataframes()
+            bb_df = bb_lazy.collect()
+            if bb_df.height > 0:
+                return candidate
+        except Exception:
+            continue
+
+    return earliest_found
+
+
+def compute_reference_for_day(
+    hydrophone: Hydrophone, target_date: dt.date
+) -> dict | None:
+    """Compute 5th percentile broadband dB for 7-day window ending on target_date."""
+    end_time = dt.datetime.combine(
+        target_date + dt.timedelta(days=1), dt.time.min
+    ).replace(tzinfo=TIMEZONE)
+    start_time = end_time - dt.timedelta(days=WINDOW_DAYS)
+
+    accessor = PartitionedAccessor(hydrophone, start_time, end_time)
+    _, bb_lazy = accessor.get_dataframes()
+    bb_df = bb_lazy.collect()
+
+    if bb_df.height == 0:
+        return None
+
+    ref_db = bb_df.select(pl.col("0").quantile(0.05)).item()
+    sample_count = bb_df.height
+
+    return {
+        "date": target_date,
+        "hydrophone": hydrophone.name,
+        "rolling_reference_db": float(ref_db),
+        "sample_count": sample_count,
+        "window_start": start_time.replace(tzinfo=None),
+        "window_end": end_time.replace(tzinfo=None),
+    }
+
+
+def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int:
+    """Process a single hydrophone. Returns number of new rows added."""
+    name = hydrophone.name
+    print(f"\nProcessing {name}...")
+
+    existing_df = read_existing(s3_client, name)
+
+    if existing_df is not None and len(existing_df) > 0:
+        last_date = existing_df.select(pl.col("date").max()).item()
+        if isinstance(last_date, dt.datetime):
+            last_date = last_date.date()
+        start_date = last_date + dt.timedelta(days=1)
+        print(f"  Found existing data through {last_date}, computing from {start_date}")
+    else:
+        existing_df = None
+        print("  No existing data found, searching for earliest available data...")
+        earliest = find_earliest_data(hydrophone, today)
+        if earliest is None:
+            print(f"  No data found for {name}, skipping.")
+            return 0
+        # Need at least WINDOW_DAYS of data for a meaningful reference
+        start_date = earliest + dt.timedelta(days=WINDOW_DAYS)
+        print(f"  Earliest data: {earliest}, starting reference from {start_date}")
+
+    if start_date > today:
+        print(f"  Already up to date.")
+        return 0
+
+    new_rows = []
+    current = start_date
+    while current <= today:
+        try:
+            row = compute_reference_for_day(hydrophone, current)
+            if row is not None:
+                new_rows.append(row)
+                print(f"  {current}: {row['rolling_reference_db']:.1f} dB ({row['sample_count']} samples)")
+            else:
+                print(f"  {current}: no data in window, skipping")
+        except Exception as e:
+            print(f"  {current}: error - {e}")
+        current += dt.timedelta(days=1)
+
+    if not new_rows:
+        print(f"  No new data computed for {name}.")
+        return 0
+
+    new_df = pl.DataFrame(new_rows).with_columns(
+        pl.col("date").cast(pl.Date),
+        pl.col("sample_count").cast(pl.Int64),
+        pl.col("window_start").cast(pl.Datetime),
+        pl.col("window_end").cast(pl.Datetime),
+    )
+
+    if existing_df is not None:
+        combined = pl.concat([existing_df, new_df])
+    else:
+        combined = new_df
+
+    write_to_s3(s3_client, name, combined)
+    return len(new_rows)
+
+
+def main():
+    print("=" * 60)
+    print("Rolling Broadband Reference Level Computation")
+    print("=" * 60)
+
+    s3_client = boto3.client("s3")
+    today = dt.datetime.now(TIMEZONE).date()
+    print(f"Today: {today}")
+
+    summary = {}
+    for hydrophone in Hydrophone:
+        try:
+            count = process_hydrophone(s3_client, hydrophone, today)
+            summary[hydrophone.name] = count
+        except Exception:
+            print(f"\nERROR processing {hydrophone.name}:")
+            traceback.print_exc()
+            summary[hydrophone.name] = "FAILED"
+
+    print("\n" + "=" * 60)
+    print("Summary:")
+    for name, result in summary.items():
+        if isinstance(result, int):
+            print(f"  {name}: {result} new rows")
+        else:
+            print(f"  {name}: {result}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/ambient_reference.py
+++ b/ambient_reference.py
@@ -1,6 +1,9 @@
 """
 Compute rolling 7-day broadband reference levels (5th percentile)
 for all Orcasound hydrophones and write results to S3.
+
+Produces per-hydrophone ref files matching the schema expected by
+the pipeline (PR #79): date, bb_ref, comm_bb_ref, ship_bb_ref.
 """
 
 import datetime as dt
@@ -16,18 +19,21 @@ from orcasound_noise.analysis.partitioned_accessor import PartitionedAccessor
 from orcasound_noise.utils import Hydrophone
 
 S3_BUCKET = "acoustic-sandbox"
-S3_PREFIX = "ambient-sound-analysis/data/rolling_reference"
 WINDOW_DAYS = 7
 TIMEZONE = ZoneInfo("US/Pacific")
-BB_REF = 1e-6  # 1 μPa reference for dB conversion
-BB_FREQ_LOW = 20
-BB_FREQ_HIGH = 20000
+
+# data_3.0 broadband columns
+BB_COL = "bb_o"
+COMM_BB_COL = "comm_bb_o"
+SHIP_BB_COL = "ship_bb_o"
 
 
 @dataclass
 class ReferenceRow:
     date: dt.date
-    rolling_reference_db: float
+    bb_ref: float
+    comm_bb_ref: float
+    ship_bb_ref: float
 
 
 def date_range(start: dt.date, end: dt.date):
@@ -38,13 +44,16 @@ def date_range(start: dt.date, end: dt.date):
         current += dt.timedelta(days=1)
 
 
-def s3_key(hydrophone_name: str) -> str:
-    return f"{S3_PREFIX}/{hydrophone_name}_reference.parquet"
+def s3_ref_key(hydrophone: Hydrophone) -> str:
+    """S3 key matching the path the pipeline reads refs from."""
+    name = hydrophone.value.name
+    folder = hydrophone.value.save_folder
+    return f"{folder}/ref/hydrophone={name}/{name}_refs.parquet"
 
 
-def read_existing(s3_client, hydrophone_name: str) -> pl.DataFrame | None:
+def read_existing(s3_client, hydrophone: Hydrophone) -> pl.DataFrame | None:
     """Read existing reference parquet from S3, or return None."""
-    key = s3_key(hydrophone_name)
+    key = s3_ref_key(hydrophone)
     try:
         obj = s3_client.get_object(Bucket=S3_BUCKET, Key=key)
         data = obj["Body"].read()
@@ -52,40 +61,43 @@ def read_existing(s3_client, hydrophone_name: str) -> pl.DataFrame | None:
     except s3_client.exceptions.NoSuchKey:
         return None
     except Exception as e:
-        print(f"  Warning: could not read existing data for {hydrophone_name}: {e}")
+        print(f"  Warning: could not read existing data for {hydrophone.name}: {e}")
         return None
 
 
-def write_to_s3(s3_client, hydrophone_name: str, df: pl.DataFrame) -> None:
+def write_to_s3(s3_client, hydrophone: Hydrophone, df: pl.DataFrame) -> None:
     """Write reference parquet to S3."""
-    key = s3_key(hydrophone_name)
+    key = s3_ref_key(hydrophone)
     buf = io.BytesIO()
     df.write_parquet(buf)
     s3_client.put_object(Bucket=S3_BUCKET, Key=key, Body=buf.getvalue())
     print(f"  Wrote {len(df)} rows to s3://{S3_BUCKET}/{key}")
 
 
-
 def compute_reference_for_day(
     hydrophone: Hydrophone, target_date: dt.date
 ) -> ReferenceRow | None:
-    """Compute 5th percentile broadband dB for 7-day window ending on target_date."""
+    """Compute 5th percentile for bb, comm, and ship bands over a 7-day window."""
     end_time = dt.datetime.combine(target_date + dt.timedelta(days=1), dt.time.min)
     start_time = end_time - dt.timedelta(days=WINDOW_DAYS)
 
     accessor = PartitionedAccessor(hydrophone, start_time, end_time)
-    bb_df = accessor.get_broadband(
-        freq_low=BB_FREQ_LOW, freq_high=BB_FREQ_HIGH, ref=BB_REF
-    ).collect()
+    _, bb_df = accessor.get_dataframes()
 
     if bb_df.height == 0:
         return None
 
-    ref_db = bb_df.select(pl.col("calc_bb").quantile(0.05)).item()
+    quantiles = bb_df.select(
+        pl.col(BB_COL).quantile(0.05).alias("bb_ref"),
+        pl.col(COMM_BB_COL).quantile(0.05).alias("comm_bb_ref"),
+        pl.col(SHIP_BB_COL).quantile(0.05).alias("ship_bb_ref"),
+    ).row(0)
 
     return ReferenceRow(
         date=target_date,
-        rolling_reference_db=float(ref_db),
+        bb_ref=float(quantiles[0]),
+        comm_bb_ref=float(quantiles[1]),
+        ship_bb_ref=float(quantiles[2]),
     )
 
 
@@ -94,7 +106,7 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int
     name = hydrophone.name
     print(f"\nProcessing {name}...")
 
-    existing_df = read_existing(s3_client, name)
+    existing_df = read_existing(s3_client, hydrophone)
 
     if existing_df is not None and len(existing_df) > 0:
         last_date = existing_df.select(pl.col("date").max()).item()
@@ -117,7 +129,7 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int
             row = compute_reference_for_day(hydrophone, current)
             if row is not None:
                 new_rows.append(row)
-                print(f"  {current}: {row.rolling_reference_db:.1f} dB")
+                print(f"  {current}: bb={row.bb_ref:.1f} comm={row.comm_bb_ref:.1f} ship={row.ship_bb_ref:.1f} dB")
             else:
                 print(f"  {current}: no data in window, skipping")
         except Exception as e:
@@ -136,7 +148,7 @@ def process_hydrophone(s3_client, hydrophone: Hydrophone, today: dt.date) -> int
     else:
         combined = new_df
 
-    write_to_s3(s3_client, name, combined)
+    write_to_s3(s3_client, hydrophone, combined)
     return len(new_rows)
 
 

--- a/backfill_reference.py
+++ b/backfill_reference.py
@@ -1,0 +1,135 @@
+"""
+Backfill historical rolling 7-day broadband reference levels for Orcasound hydrophones.
+
+Usage:
+    python backfill_reference.py --start 2023-01-01
+    python backfill_reference.py --start 2023-01-01 --end 2024-12-31
+    python backfill_reference.py --start 2023-01-01 --hydrophone BUSH_POINT
+"""
+
+import argparse
+import datetime as dt
+import traceback
+
+import boto3
+import polars as pl
+
+from orcasound_noise.utils import Hydrophone
+
+from ambient_reference import (
+    TIMEZONE,
+    WINDOW_DAYS,
+    ReferenceRow,
+    compute_reference_for_day,
+    date_range,
+    read_existing,
+    write_to_s3,
+)
+
+
+def backfill_hydrophone(
+    s3_client, hydrophone: Hydrophone, start: dt.date, end: dt.date
+) -> int:
+    """Backfill reference levels for a hydrophone over a date range."""
+    from dataclasses import asdict
+
+    name = hydrophone.name
+    print(f"\nBackfilling {name} from {start} to {end}...")
+
+    existing_df = read_existing(s3_client, name)
+    existing_dates: set[dt.date] = set()
+    if existing_df is not None and len(existing_df) > 0:
+        dates_col = existing_df.select(pl.col("date")).to_series()
+        existing_dates = {
+            d.date() if isinstance(d, dt.datetime) else d for d in dates_col
+        }
+        print(f"  Found {len(existing_dates)} existing rows, skipping those dates")
+
+    new_rows = []
+    for current in date_range(start, end):
+        if current in existing_dates:
+            continue
+        try:
+            row = compute_reference_for_day(hydrophone, current)
+            if row is not None:
+                new_rows.append(row)
+                print(f"  {current}: {row.rolling_reference_db:.1f} dB ({row.sample_count} samples)")
+            else:
+                print(f"  {current}: no data in window, skipping")
+        except Exception as e:
+            print(f"  {current}: error - {e}")
+
+    if not new_rows:
+        print(f"  No new data computed for {name}.")
+        return 0
+
+    new_df = pl.DataFrame([asdict(row) for row in new_rows]).with_columns(
+        pl.col("date").cast(pl.Date),
+        pl.col("sample_count").cast(pl.Int64),
+        pl.col("window_start").cast(pl.Datetime),
+        pl.col("window_end").cast(pl.Datetime),
+    )
+
+    if existing_df is not None:
+        combined = pl.concat([existing_df, new_df]).sort("date")
+    else:
+        combined = new_df.sort("date")
+
+    write_to_s3(s3_client, name, combined)
+    return len(new_rows)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Backfill broadband reference levels")
+    parser.add_argument(
+        "--start", required=True, type=lambda s: dt.date.fromisoformat(s),
+        help="Start date (YYYY-MM-DD)",
+    )
+    parser.add_argument(
+        "--end", type=lambda s: dt.date.fromisoformat(s), default=None,
+        help="End date (YYYY-MM-DD), defaults to today",
+    )
+    parser.add_argument(
+        "--hydrophone", type=str, default=None,
+        help=f"Hydrophone name (e.g. BUSH_POINT). Defaults to all. Options: {', '.join(h.name for h in Hydrophone)}",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    today = dt.datetime.now(TIMEZONE).date()
+    end = args.end or today
+
+    if args.hydrophone:
+        hydrophones = [Hydrophone[args.hydrophone]]
+    else:
+        hydrophones = list(Hydrophone)
+
+    print(f"Backfill range: {args.start} to {end}")
+    print(f"Hydrophones: {', '.join(h.name for h in hydrophones)}")
+
+    s3_client = boto3.client("s3")
+    summary = {}
+
+    for hydrophone in hydrophones:
+        try:
+            count = backfill_hydrophone(s3_client, hydrophone, args.start, end)
+            summary[hydrophone.name] = count
+        except Exception:
+            print(f"\nERROR processing {hydrophone.name}:")
+            traceback.print_exc()
+            summary[hydrophone.name] = None
+
+    print("\n" + "=" * 60)
+    print("Backfill Summary:")
+    for name, result in summary.items():
+        if result is None:
+            print(f"  {name}: FAILED")
+        else:
+            print(f"  {name}: {result} new rows")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/backfill_reference.py
+++ b/backfill_reference.py
@@ -10,6 +10,7 @@ Usage:
 import argparse
 import datetime as dt
 import traceback
+from dataclasses import asdict
 
 import boto3
 import polars as pl
@@ -29,12 +30,10 @@ def backfill_hydrophone(
     s3_client, hydrophone: Hydrophone, start: dt.date, end: dt.date
 ) -> int:
     """Backfill reference levels for a hydrophone over a date range."""
-    from dataclasses import asdict
-
     name = hydrophone.name
     print(f"\nBackfilling {name} from {start} to {end}...")
 
-    existing_df = read_existing(s3_client, name)
+    existing_df = read_existing(s3_client, hydrophone)
     existing_dates: set[dt.date] = set()
     if existing_df is not None and len(existing_df) > 0:
         dates_col = existing_df.select(pl.col("date")).to_series()
@@ -51,7 +50,7 @@ def backfill_hydrophone(
             row = compute_reference_for_day(hydrophone, current)
             if row is not None:
                 new_rows.append(row)
-                print(f"  {current}: {row.rolling_reference_db:.1f} dB")
+                print(f"  {current}: bb={row.bb_ref:.1f} comm={row.comm_bb_ref:.1f} ship={row.ship_bb_ref:.1f} dB")
             else:
                 print(f"  {current}: no data in window, skipping")
         except Exception as e:
@@ -70,7 +69,7 @@ def backfill_hydrophone(
     else:
         combined = new_df.sort("date")
 
-    write_to_s3(s3_client, name, combined)
+    write_to_s3(s3_client, hydrophone, combined)
     return len(new_rows)
 
 

--- a/backfill_reference.py
+++ b/backfill_reference.py
@@ -85,7 +85,7 @@ def parse_args():
     )
     parser.add_argument(
         "--hydrophone", type=str, default=None,
-        help=f"Hydrophone name (e.g. BUSH_POINT). Defaults to all. Options: {', '.join(h.name for h in Hydrophone)}",
+        help=f"Hydrophone name (e.g. BUSH_POINT). Defaults to all. Options: {', '.join(h.name for h in Hydrophone if h.name != 'HPhoneTup')}",
     )
     return parser.parse_args()
 
@@ -98,7 +98,7 @@ def main():
     if args.hydrophone:
         hydrophones = [Hydrophone[args.hydrophone]]
     else:
-        hydrophones = list(Hydrophone)
+        hydrophones = [h for h in Hydrophone if h.name != "HPhoneTup"]
 
     print(f"Backfill range: {args.start} to {end}")
     print(f"Hydrophones: {', '.join(h.name for h in hydrophones)}")

--- a/backfill_reference.py
+++ b/backfill_reference.py
@@ -18,8 +18,6 @@ from orcasound_noise.utils import Hydrophone
 
 from ambient_reference import (
     TIMEZONE,
-    WINDOW_DAYS,
-    ReferenceRow,
     compute_reference_for_day,
     date_range,
     read_existing,
@@ -53,7 +51,7 @@ def backfill_hydrophone(
             row = compute_reference_for_day(hydrophone, current)
             if row is not None:
                 new_rows.append(row)
-                print(f"  {current}: {row.rolling_reference_db:.1f} dB ({row.sample_count} samples)")
+                print(f"  {current}: {row.rolling_reference_db:.1f} dB")
             else:
                 print(f"  {current}: no data in window, skipping")
         except Exception as e:
@@ -65,9 +63,6 @@ def backfill_hydrophone(
 
     new_df = pl.DataFrame([asdict(row) for row in new_rows]).with_columns(
         pl.col("date").cast(pl.Date),
-        pl.col("sample_count").cast(pl.Int64),
-        pl.col("window_start").cast(pl.Datetime),
-        pl.col("window_end").cast(pl.Datetime),
     )
 
     if existing_df is not None:

--- a/requirements_reference.txt
+++ b/requirements_reference.txt
@@ -1,0 +1,5 @@
+polars
+boto3
+pytz
+pyarrow
+orcasound_noise@git+https://github.com/orcasound/ambient-sound-analysis@MSDS-2026-main

--- a/requirements_reference.txt
+++ b/requirements_reference.txt
@@ -1,5 +1,4 @@
 polars
 boto3
-pytz
 pyarrow
 orcasound_noise@git+https://github.com/orcasound/ambient-sound-analysis@MSDS-2026-main


### PR DESCRIPTION
## Summary
- Adds `ambient_reference.py` — computes rolling 7-day broadband reference levels (5th percentile) for all Orcasound hydrophones and writes results to S3
- Adds `backfill_reference.py` — backfills historical reference levels over a date range
- Adds GitHub Actions workflow (`ambient_reference.yml`) to run the reference computation daily at 10pm PST
- Adds `requirements_reference.txt` for the workflow's Python dependencies

## Details
- Uses the most recent 604,800 data points (7 days at 1-second resolution) ending at "now", expanding lookback up to 14 calendar days to handle data gaps
- Stores results under tomorrow's date so the PSD pipeline always has a ref value available
- Produces per-hydrophone `_ref.parquet` files matching the schema expected by the pipeline: `date`, `bb_ref`, `comm_bb_ref`, `ship_bb_ref`
- Bootstrap logic for early days without a full 7-day window uses 5th percentile of the first 7 days as a static reference
- Supports `--test` flag to write to a test S3 prefix instead of production

## Test plan
- [x] Ran with `--test` flag to verify S3 writes to test prefix
- [x] Verified parquet schema matches pipeline expectations
- [x] Confirmed idempotency (re-runs update tomorrow's row without duplicating)
- [ ] Verify GitHub Actions workflow runs successfully with repo secrets